### PR TITLE
Expose thread-safe array methods from PdBase

### DIFF
--- a/src/PureDataNode.cpp
+++ b/src/PureDataNode.cpp
@@ -109,4 +109,19 @@ void PureDataNode::sendMessage( const std::string& dest, const std::string& msg,
 	mPdBase.sendMessage( dest, msg, list );
 }
 
+bool PureDataNode::readArray( const std::string& arrayName, std::vector<float>& dest, int readLen, int offset ) {
+	lock_guard<mutex> lock( mMutex );
+	return mPdBase.readArray( arrayName, dest, readLen, offset );
+}
+
+bool PureDataNode::writeArray( const std::string& arrayName, std::vector<float>& source, int writeLen, int offset ) {
+	lock_guard<mutex> lock( mMutex );
+	return mPdBase.writeArray( arrayName, source, writeLen, offset );
+}
+
+void PureDataNode::clearArray( const std::string& arrayName, int value ) {
+	lock_guard<mutex> lock( mMutex );
+	mPdBase.clearArray( arrayName, value );
+}
+
 } // namespace cipd

--- a/src/PureDataNode.h
+++ b/src/PureDataNode.h
@@ -32,6 +32,10 @@ public:
 	void sendList(const std::string& dest, const pd::List& list);
 	void sendMessage(const std::string& dest, const std::string& msg, const pd::List& list = pd::List());
 
+	bool readArray(const std::string& arrayName, std::vector<float>& dest, int readLen = -1, int offset = 0);
+	bool writeArray(const std::string& arrayName, std::vector<float>& source, int writeLen = -1, int offset = 0);
+	void clearArray(const std::string& arrayName, int value = 0);
+
 private:
 	pd::PdBase	mPdBase;
 	std::mutex	mMutex;


### PR DESCRIPTION
Just some straightforward pass-through methods with a lock.
